### PR TITLE
fix create.go for gitlab

### DIFF
--- a/pkg/cmd/create/create.go
+++ b/pkg/cmd/create/create.go
@@ -934,5 +934,10 @@ func CollapseDependencyUpdates(dependencyUpdates []v1.DependencyUpdate) []v1.Dep
 }
 
 func isReleaseNotFound(err error, gitKind string) bool {
-	return scmhelpers.IsScmNotFound(err)
+	switch gitKind {
+		case "gitlab":
+			return strings.Contains(err.Error(), "Forbidden") || scmhelpers.IsScmNotFound(err)
+		default:
+			return scmhelpers.IsScmNotFound(err)
+	}
 }


### PR DESCRIPTION
private gitlab returns forbidden on non-existing tags
see also [my issue on go-scm] regarding response codes(https://github.com/jenkins-x/go-scm/issues/302)
go-scm helper IsScmNotFound() cannot distinguish the gitKind, so aplied the fix in isReleaseNotFound()

Signed-off-by: Manuel Stein <manuel.stein@nokia-bell-labs.com>