### PR TITLE
fix: reduce changelog image size by removing unrelated binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-FROM ghcr.io/jenkins-x/jx-boot:latest
+FROM ghcr.io/jenkins-x/jx-boot:latest as builder
 
+FROM alpine:3.16.0
+COPY --from=builder /usr/bin/jx /usr/bin/jx
+COPY --from=builder /root/.jx/plugins/bin/jx-gitops* /root/.jx3/plugins/bin/
 RUN apk --no-cache add sed
-    
 COPY ./build/linux/jx-changelog /usr/bin/jx-changelog


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

This reduces the size from 870 MB to 190 MB.
Would be good to test this out first.