### PR TITLE
propagate changelogs from PRs

### DIFF
--- a/docs/cmd/jx-changelog_create.md
+++ b/docs/cmd/jx-changelog_create.md
@@ -24,7 +24,16 @@ This command also generates a Release Custom Resource Definition you can include
 
 You can opt out of the release YAML generation via the '--generate-yaml=false' option 
 
-To update the release notes on your git provider needs a git API token which is usually provided via the Tekton git authentication mechanism.
+To update the release notes on your git provider needs a git API token which is usually provided via the Tekton git authentication mechanism. 
+
+Apart from using your git provider as the issue tracker there is also support for Jira. You then specify issues in commit messages with the issue key that looks like ABC-123. You can configure this in in similar ways as environments, see https://jenkins-x.io/v3/develop/environments/config/. An example configuration: 
+
+  issueProvider:
+    jira:
+      serverUrl: https://example.atlassian.net
+      userName: user@example.com
+
+Jira API token is taken from the environment variable JIRA_API_TOKEN. Can be populated using the jx-boot-job-env-vars secret.
 
 By default jx commands look for a file '~/.jx/gitAuth.yaml' to find the API tokens for Git servers. You can use 'jx create git token' to create a Git token.
 
@@ -46,41 +55,44 @@ e.g. define environment variables GIT_USERNAME and GIT_API_TOKEN
 ### Options
 
 ```
-  -b, --batch-mode                 Runs in batch mode without prompting for user input
-      --build string               The Build number which is used to update the PipelineActivity. If not specified its defaulted from  the '$BUILD_NUMBER' environment variable
-      --conditional-release        Wrap the Release YAML in the helm Capabilities.APIVersions.Has if statement (default true)
-  -c, --crd                        Generate the CRD in the chart
-      --crd-yaml-file string       the name of the file to generate the Release CustomResourceDefinition YAML (default "release-crd.yaml")
-      --dir string                 the directory to search for the .git to discover the git source URL (default ".")
-      --draft                      The git provider release is marked as draft
-      --fail-if-no-commits         Do we want to fail the build if we don't find any commits to generate the changelog
-      --footer string              The changelog footer in markdown for the changelog. Can use go template expressions on the ReleaseSpec object: https://golang.org/pkg/text/template/
-      --footer-file string         The file name of the changelog footer in markdown for the changelog. Can use go template expressions on the ReleaseSpec object: https://golang.org/pkg/text/template/
-  -y, --generate-yaml              Generate the Release YAML in the local helm chart
-      --git-kind string            the kind of git server to connect to
-      --git-server string          the git server URL to create the git provider client. If not specified its defaulted from the current source URL
-      --git-token string           the git token used to operate on the git repository
-      --header string              The changelog header in markdown for the changelog. Can use go template expressions on the ReleaseSpec object: https://golang.org/pkg/text/template/
-      --header-file string         The file name of the changelog header in markdown for the changelog. Can use go template expressions on the ReleaseSpec object: https://golang.org/pkg/text/template/
-  -h, --help                       help for create
-      --include-merge-commits      Include merge commits when generating the changelog
-      --log-level string           Sets the logging level. If not specified defaults to $JX_LOG_LEVEL
-      --no-dev-release             Disables the generation of Release CRDs in the development namespace to track releases being performed
-      --output-markdown string     Put the changelog output in this file
-  -o, --overwrite                  overwrites the Release CRD YAML file if it exists
-      --prerelease                 The git provider release is marked as a pre-release
-      --previous-date string       the previous date to find a revision in format 'MonthName dayNumber year'
-  -p, --previous-rev string        the previous tag revision
-      --release-yaml-file string   the name of the file to generate the Release YAML (default "release.yaml")
-      --rev string                 the current tag revision
-  -t, --templates-dir string       the directory containing the helm chart templates to generate the resources
-      --update-release             Should we update the release on the Git repository with the changelog (default true)
-      --verbose                    Enables verbose output. The environment variable JX_LOG_LEVEL has precedence over this flag and allows setting the logging level to any value of: panic, fatal, error, warn, info, debug, trace
-  -v, --version string             The version to release
+  -b, --batch-mode                   Runs in batch mode without prompting for user input
+      --build string                 The Build number which is used to update the PipelineActivity. If not specified its defaulted from  the '$BUILD_NUMBER' environment variable
+      --changelog-separator string   the separator to use when splitting commit message from changelog in the pull request body. Default to ----- or if set the CHANGELOG_SEPARATOR environment variable
+      --conditional-release          Wrap the Release YAML in the helm Capabilities.APIVersions.Has if statement (default true)
+  -c, --crd                          Generate the CRD in the chart
+      --crd-yaml-file string         the name of the file to generate the Release CustomResourceDefinition YAML (default "release-crd.yaml")
+      --dir string                   the directory to search for the .git to discover the git source URL (default ".")
+      --draft                        The git provider release is marked as draft
+      --fail-if-no-commits           Do we want to fail the build if we don't find any commits to generate the changelog
+      --footer string                The changelog footer in markdown for the changelog. Can use go template expressions on the ReleaseSpec object: https://golang.org/pkg/text/template/
+      --footer-file string           The file name of the changelog footer in markdown for the changelog. Can use go template expressions on the ReleaseSpec object: https://golang.org/pkg/text/template/
+  -y, --generate-yaml                Generate the Release YAML in the local helm chart
+      --git-kind string              the kind of git server to connect to
+      --git-server string            the git server URL to create the git provider client. If not specified its defaulted from the current source URL
+      --git-token string             the git token used to operate on the git repository
+      --header string                The changelog header in markdown for the changelog. Can use go template expressions on the ReleaseSpec object: https://golang.org/pkg/text/template/
+      --header-file string           The file name of the changelog header in markdown for the changelog. Can use go template expressions on the ReleaseSpec object: https://golang.org/pkg/text/template/
+  -h, --help                         help for create
+      --include-changelog            Should changelogs from pull requests be included. Defaults to true (default true)
+      --include-merge-commits        Include merge commits when generating the changelog
+      --log-level string             Sets the logging level. If not specified defaults to $JX_LOG_LEVEL
+      --no-dev-release               Disables the generation of Release CRDs in the development namespace to track releases being performed
+      --output-markdown string       Put the changelog output in this file
+  -o, --overwrite                    overwrites the Release CRD YAML file if it exists
+      --prerelease                   The git provider release is marked as a pre-release
+      --previous-date string         the previous date to find a revision in format 'MonthName dayNumber year'
+  -p, --previous-rev string          the previous tag revision
+      --release-yaml-file string     the name of the file to generate the Release YAML (default "release.yaml")
+      --rev string                   the current tag revision
+      --tag-prefix string            prefix to filter on when searching for version tags
+  -t, --templates-dir string         the directory containing the helm chart templates to generate the resources
+      --update-release               Should we update the release on the Git repository with the changelog (default true)
+      --verbose                      Enables verbose output. The environment variable JX_LOG_LEVEL has precedence over this flag and allows setting the logging level to any value of: panic, fatal, error, warn, info, debug, trace
+  -v, --version string               The version to release
 ```
 
 ### SEE ALSO
 
 * [jx-changelog](jx-changelog.md)	 - Command for working with Changelogs
 
-###### Auto generated by spf13/cobra on 11-Oct-2021
+###### Auto generated by spf13/cobra on 21-Nov-2022

--- a/docs/man/man1/jx-changelog-create.1
+++ b/docs/man/man1/jx-changelog-create.1
@@ -37,6 +37,20 @@ You can opt out of the release YAML generation via the '\-\-generate\-yaml=false
 To update the release notes on your git provider needs a git API token which is usually provided via the Tekton git authentication mechanism.
 
 .PP
+Apart from using your git provider as the issue tracker there is also support for Jira. You then specify issues in commit messages with the issue key that looks like ABC\-123. You can configure this in in similar ways as environments, see 
+\[la]https://jenkins-x.io/v3/develop/environments/config/\[ra]\&. An example configuration:
+
+.PP
+issueProvider:
+    jira:
+      serverUrl: 
+\[la]https://example.atlassian.net\[ra]
+      userName: user@example.com
+
+.PP
+Jira API token is taken from the environment variable JIRA\_API\_TOKEN. Can be populated using the jx\-boot\-job\-env\-vars secret.
+
+.PP
 By default jx commands look for a file '\~/.jx/gitAuth.yaml' to find the API tokens for Git servers. You can use 'jx create git token' to create a Git token.
 
 .PP
@@ -52,6 +66,10 @@ e.g. define environment variables GIT\_USERNAME and GIT\_API\_TOKEN
 .PP
 \fB\-\-build\fP=""
     The Build number which is used to update the PipelineActivity. If not specified its defaulted from  the '$BUILD\_NUMBER' environment variable
+
+.PP
+\fB\-\-changelog\-separator\fP=""
+    the separator to use when splitting commit message from changelog in the pull request body. Default to \-\-\-\-\- or if set the CHANGELOG\_SEPARATOR environment variable
 
 .PP
 \fB\-\-conditional\-release\fP[=true]
@@ -118,6 +136,10 @@ e.g. define environment variables GIT\_USERNAME and GIT\_API\_TOKEN
     help for create
 
 .PP
+\fB\-\-include\-changelog\fP[=true]
+    Should changelogs from pull requests be included. Defaults to true
+
+.PP
 \fB\-\-include\-merge\-commits\fP[=false]
     Include merge commits when generating the changelog
 
@@ -156,6 +178,10 @@ e.g. define environment variables GIT\_USERNAME and GIT\_API\_TOKEN
 .PP
 \fB\-\-rev\fP=""
     the current tag revision
+
+.PP
+\fB\-\-tag\-prefix\fP=""
+    prefix to filter on when searching for version tags
 
 .PP
 \fB\-t\fP, \fB\-\-templates\-dir\fP=""

--- a/pkg/gits/commits.go
+++ b/pkg/gits/commits.go
@@ -116,7 +116,7 @@ func (c *CommitInfo) Order() int {
 
 type GroupAndCommitInfos struct {
 	group   *CommitGroup
-	commits *linkedhashset.Set
+	commits *linkedhashset.Set // duplicate commit messages should not show up in changelog
 }
 
 // GenerateMarkdown generates the markdown document for the commits

--- a/pkg/gits/commits.go
+++ b/pkg/gits/commits.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/emirpasic/gods/sets/linkedhashset"
 	v1 "github.com/jenkins-x/jx-api/v4/pkg/apis/jenkins.io/v1"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/gitclient/giturl"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/stringhelpers"
@@ -115,11 +116,11 @@ func (c *CommitInfo) Order() int {
 
 type GroupAndCommitInfos struct {
 	group   *CommitGroup
-	commits []string
+	commits *linkedhashset.Set
 }
 
 // GenerateMarkdown generates the markdown document for the commits
-func GenerateMarkdown(releaseSpec *v1.ReleaseSpec, gitInfo *giturl.GitRepository) (string, error) {
+func GenerateMarkdown(releaseSpec *v1.ReleaseSpec, gitInfo *giturl.GitRepository, changelogSeparator string, prchangelog, includeprs bool) (string, error) {
 	var hasCommitInfos bool
 
 	groupAndCommits := map[int]*GroupAndCommitInfos{}
@@ -152,12 +153,12 @@ func GenerateMarkdown(releaseSpec *v1.ReleaseSpec, gitInfo *giturl.GitRepository
 		return "", nil
 	}
 
-	buffer.WriteString("## Changes\n")
+	buffer.WriteString("## Changes in version " + releaseSpec.Version + "\n")
 
 	hasTitle := false
 	for i := undefinedGroupCounter; i <= unknownKindOrder; i++ {
 		gac := groupAndCommits[i]
-		if gac != nil && len(gac.commits) > 0 {
+		if gac != nil && len(gac.commits.Values()) > 0 {
 			group := gac.group
 			if group != nil {
 				legend := ""
@@ -170,12 +171,8 @@ func GenerateMarkdown(releaseSpec *v1.ReleaseSpec, gitInfo *giturl.GitRepository
 					}
 				}
 			}
-			previous := ""
-			for _, msg := range gac.commits {
-				if msg != previous {
-					buffer.WriteString(msg)
-					previous = msg
-				}
+			for _, msg := range gac.commits.Values() {
+				buffer.WriteString(msg.(string))
 			}
 		}
 	}
@@ -183,27 +180,17 @@ func GenerateMarkdown(releaseSpec *v1.ReleaseSpec, gitInfo *giturl.GitRepository
 	if len(issues) > 0 {
 		buffer.WriteString("\n### Issues\n\n")
 
-		previous := ""
 		for k := range issues {
-			i := issues[k]
-			msg := describeIssue(gitInfo, &i)
-			if msg != previous {
-				buffer.WriteString("* " + msg + "\n")
-				previous = msg
-			}
+			buffer.WriteString(describeIssue(gitInfo, &issues[k], false, "", true))
 		}
 	}
 	if len(prs) > 0 {
-		buffer.WriteString("\n### Pull Requests\n\n")
-
-		previous := ""
+		if includeprs {
+			buffer.WriteString("\n### Pull Requests\n\n")
+		}
 		for k := range prs {
-			pullRequest := prs[k]
-			msg := describeIssue(gitInfo, &pullRequest)
-			if msg != previous {
-				buffer.WriteString("* " + msg + "\n")
-				previous = msg
-			}
+			buffer.WriteString(describeIssue(gitInfo, &prs[k], prchangelog, changelogSeparator, includeprs))
+
 		}
 	}
 
@@ -239,15 +226,25 @@ func addCommitToGroup(gitInfo *giturl.GitRepository, commits *v1.CommitSummary, 
 	if gac == nil {
 		gac = &GroupAndCommitInfos{
 			group:   group,
-			commits: []string{},
+			commits: linkedhashset.New(),
 		}
 		groupAndCommits[group.Order] = gac
 	}
-	gac.commits = append(gac.commits, description)
+	gac.commits.Add(description)
 }
 
-func describeIssue(info *giturl.GitRepository, issue *v1.IssueSummary) string {
-	return describeIssueShort(issue) + issue.Title + describeUser(info, issue.User)
+func describeIssue(info *giturl.GitRepository, issue *v1.IssueSummary, includeChangelog bool, separator string, includeDescription bool) string {
+	changelog := ""
+	if includeChangelog {
+		parts := strings.SplitN(issue.Body, separator, 2)
+		if len(parts) == 2 {
+			changelog = "\n" + parts[1]
+		}
+	}
+	if includeDescription {
+		return "* " + describeIssueShort(issue) + issue.Title + describeUser(info, issue.User) + "\n" + changelog
+	}
+	return changelog
 }
 
 func describeIssueShort(issue *v1.IssueSummary) string {

--- a/pkg/gits/commits_integration_test.go
+++ b/pkg/gits/commits_integration_test.go
@@ -14,6 +14,7 @@ import (
 
 func TestChangelogMarkdown(t *testing.T) {
 	releaseSpec := &v1.ReleaseSpec{
+		Version: "1",
 		Commits: []v1.CommitSummary{
 			{
 				Message: "some commit 1\nfixes #123",
@@ -38,11 +39,11 @@ func TestChangelogMarkdown(t *testing.T) {
 		Organisation: "jstrachan",
 		Name:         "foo",
 	}
-	markdown, err := gits.GenerateMarkdown(releaseSpec, gitInfo)
+	markdown, err := gits.GenerateMarkdown(releaseSpec, gitInfo, "", false, false)
 	assert.Nil(t, err)
 	//t.Log("Generated => " + markdown)
 
-	expectedMarkdown := `## Changes
+	expectedMarkdown := `## Changes in version 1
 
 * some commit 1 ([jstrachan](https://github.com/jstrachan))
 * some commit 2 ([rawlingsj](https://github.com/rawlingsj))
@@ -52,6 +53,7 @@ func TestChangelogMarkdown(t *testing.T) {
 
 func TestChangelogMarkdownWithConventionalCommits(t *testing.T) {
 	releaseSpec := &v1.ReleaseSpec{
+		Version: "2",
 		Commits: []v1.CommitSummary{
 			{
 				Message: "fix: some commit 1\nfixes #123",
@@ -124,17 +126,38 @@ BREAKING CHANGE: The git has fobbed!
 				URL: "http://url-to-issue/345",
 			},
 		},
+		PullRequests: []v1.IssueSummary{
+			{
+				ID:    "789",
+				Title: "Upgrade of foo/bar to 1.2.3",
+				Body: `Bumps foo/bar from 1.2.2 to 1.2.3.
+-----
+# bar
+
+## Changes in version 1.2.3
+
+### New Features
+
+* The bar is open!
+`,
+				User: &v1.UserDetails{
+					Name:  "Ankit",
+					Login: "ankit",
+				},
+				URL: "http://url-to-pull/789",
+			},
+		},
 	}
 	gitInfo := &giturl.GitRepository{
 		Host:         "github.com",
 		Organisation: "jstrachan",
 		Name:         "foo",
 	}
-	markdown, err := gits.GenerateMarkdown(releaseSpec, gitInfo)
+	markdown, err := gits.GenerateMarkdown(releaseSpec, gitInfo, "-----", true, false)
 	assert.Nil(t, err)
 	//t.Log("Generated => " + markdown)
 
-	expectedMarkdown := `## Changes
+	expectedMarkdown := `## Changes in version 2
 
 ### FOO-123
 
@@ -164,9 +187,18 @@ These commits did not use [Conventional Commits](https://conventionalcommits.org
 
 * [#456](http://url-to-issue/456) This needs to be fixed ASAP! ([jstrachan](https://github.com/jstrachan))
 * [#345](http://url-to-issue/345) The shit has hit the fan! ([msvticket](https://github.com/msvticket))
+
+
+# bar
+
+## Changes in version 1.2.3
+
+### New Features
+
+* The bar is open!
 `
 	assert.Equal(t, expectedMarkdown, markdown)
 
 }
 
-// TODO: Add tests for JIRA ass issue tracker
+// TODO: Add tests for JIRA as issue tracker


### PR DESCRIPTION
This pull request includes:

- support for including changelogs without including merge commits and PRs
- check for PRs even though issue tracker is JIRA
- test for propagated changelog
- deduplication of commit messages
- adding version in changelog so concatenated changes get clearer
- some cleanup of code

When regenerating the docs some functionality that previously where added got added to the docs as well.

Partial fix of jenkins-x/jx#8466