### PR TITLE
fix: make git silent

### DIFF
--- a/.jx/updatebot.yaml
+++ b/.jx/updatebot.yaml
@@ -3,13 +3,6 @@ kind: UpdateConfig
 spec:
   rules:
   - urls:
-      - https://github.com/jenkins-x/jx3-pipeline-catalog
-    changes:
-      - regex:
-          pattern: "jenkins-x/jx-changelog:(.*)"
-          files:
-            - "**/*.yaml"
-  - urls:
     - https://github.com/jenkins-x/jx
     changes:
     - regex:

--- a/pkg/cmd/create/create.go
+++ b/pkg/cmd/create/create.go
@@ -275,6 +275,9 @@ func (o *Options) Validate() error {
 			return errors.Wrapf(err, "invalid regexp for option --exclude-regexp")
 		}
 	}
+	if o.CommandRunner == nil {
+		o.CommandRunner = cmdrunner.QuietCommandRunner
+	}
 
 	return nil
 }
@@ -961,7 +964,7 @@ func (o *Options) getDependencyUpdates(previousRev string) ([]v1.DependencyUpdat
 		log.Logger().Debugf("file %s doesn't exists", absStatusPath)
 		return nil, nil
 	}
-	previousReleasesBlob, err := o.GitClient.Command(dir, "cat-file", "blob", previousRev+":"+o.StatusPath)
+	previousReleasesBlob, err := o.Git().Command(dir, "cat-file", "blob", previousRev+":"+o.StatusPath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "fail to check if %s exists for %s", o.StatusPath, previousRev)
 	}


### PR DESCRIPTION
don't show output of git commands

I don't see that it is useful to log all git commands at info level, debug level suffices.
This is especially true for cat-file

I realised that the jx-changelog image downloads jx-changelog, the jx-boot image doesn't. So I remove the update of jx3-pipline-catalog. When this is merged I'll fix jenkins-x/jx3-pipeline-catalog#1334