### PR TITLE
fix: stop building image

### DIFF
--- a/.lighthouse/jenkins-x/release.yaml
+++ b/.lighthouse/jenkins-x/release.yaml
@@ -25,20 +25,11 @@ spec:
           resources: {}
         - name: release-binary
           resources: {}
-        - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/build-scan-push/build-scan-push.yaml@versionStream
-          name: build-container
-        - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/build-scan-push/build-scan-push.yaml@versionStream
-          name: push-container
         - name: chart-docs
           resources: {}
         - name: release-chart
           resources: {}
         - name: changelog
-          resources: {}
-        - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/supply-chain-security/task.yaml@versionStream
-          name: download-syft
-        - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/supply-chain-security/task.yaml@versionStream
-          name: build-and-push-sbom
           resources: {}
         - name: upload-binaries
           resources: {}


### PR DESCRIPTION
when using the jx-changelog image the command jx changelog download jx-changelog anyway (can be avoided by using of jx-changelog instead)

depends on #49 and jenkins-x/jx3-pipeline-catalog#1339